### PR TITLE
Standalone test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/composer.lock
+/vendor

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
   "require": {
     "php": "~5.6 || ^7.0",
     "alom/graphviz": "~1.0",
+    "doctrine/collections": "~1.3",
     "doctrine/doctrine-bundle": "~1.4",
     "doctrine/orm": "~2.1",
     "ocramius/proxy-manager": "~1.0 || ~2.0",

--- a/src/test_bootstrap.php
+++ b/src/test_bootstrap.php
@@ -1,16 +1,10 @@
 <?php
 
-if (!($loader = include __DIR__.'/../vendor/autoload.php')) {
-    die(<<<EOT
-You need to install the project dependencies using Composer:
-$ wget http://getcomposer.org/composer.phar
-OR
-$ curl -s https://getcomposer.org/installer | php
-$ php composer.phar install
-$ phpunit
-EOT
-    );
+error_reporting(E_ALL | E_STRICT);
+// Ensure that composer has installed all dependencies
+if (!file_exists(dirname(__DIR__) . '/composer.lock')) {
+    die("Dependencies must be installed using composer:\n\nphp composer.phar install --dev\n\n"
+        . "See http://getcomposer.org for help with installing composer\n");
 }
-// Need to load the state machine bundle for tests in that directory to find its own classes.
-$loader->add('StateMachineBundle', __DIR__);
-date_default_timezone_set('Europe/Berlin');
+// Include the composer autoloader
+require dirname(__DIR__) . '/vendor/autoload.php';


### PR DESCRIPTION
💁  These changes facilitate running the test suites for `StateMachine` and `StateMachineBundle` as a standalone package, i.e. without being run inside the context of a Symfony application.

📝  Still to do:
- [ ] Clean up interface errors

```
Argument 1 passed to StateMachine\StateMachine\PersistentManager::__construct() must be an instance of Doctrine\Common\Persistence\ObjectManager, instance of Mock_EntityManager_7f57dd13 given, called in ./src/StateMachine/Tests/PersistentManagerTest.php on line 18 and defined

./src/StateMachine/StateMachine/PersistentManager.php:19
./src/StateMachine/Tests/PersistentManagerTest.php:18
```
- [ ] Clean up fatal errors

```
PHP Fatal error:  Call to undefined method Mock_RegistryInterface_1993ad6f::getManagerForClass() in ./src/StateMachineBundle/History/PersistentHistoryManager.php on line 63

Fatal error: Call to undefined method Mock_RegistryInterface_1993ad6f::getManagerForClass() in ./src/StateMachineBundle/History/PersistentHistoryManager.php on line 63
```
