### PR TITLE
CEP-402 upgrade php7 sf 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
    build:
      docker:
-       - image: circleci/php:5.6-fpm
+       - image: circleci/php:7.1-cli
      steps:
        - run: echo 'date.timezone = Europe/Berlin' | sudo tee --append /usr/local/etc/php/php.ini
        - run: echo 'memory_limit=1024M' | sudo tee --append /usr/local/etc/php/php.ini

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,17 @@
+version: 2
+jobs:
+   build:
+     docker:
+       - image: circleci/php:5.6-fpm
+     steps:
+       - run: echo 'date.timezone = Europe/Berlin' | sudo tee --append /usr/local/etc/php/php.ini
+       - run: echo 'memory_limit=1024M' | sudo tee --append /usr/local/etc/php/php.ini
+       - checkout
+       - run:
+           name: Composer install
+           command: |
+             sudo composer self-update
+             composer install -n --prefer-dist
+       - run:
+           name: Run unit tests
+           command: ./vendor/bin/phpunit --configuration=src/phpunit.xml.dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,5 +13,12 @@ jobs:
              sudo composer self-update
              composer install -n --prefer-dist
        - run:
+           name: Check code style
+           command: |
+             MASTER_MERGE_BASE=($(git merge-base origin/master HEAD))
+             COMMIT_RANGE="$MASTER_MERGE_BASE..HEAD"
+             IFS=$'\n'; COMMIT_SCA_FILES=($(git diff --name-only --diff-filter=ACMRTUXB "${COMMIT_RANGE}")); unset IFS
+             ./vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --using-cache=no --path-mode=intersection "${COMMIT_SCA_FILES[@]}"
+       - run:
            name: Run unit tests
            command: ./vendor/bin/phpunit --configuration=src/phpunit.xml.dist

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,15 @@
+<?php
+
+return PhpCsFixer\Config::create()
+    ->setRules(array(
+        '@Symfony' => true,
+        '@Symfony:risky' => true,
+        'array_syntax' => array('syntax' => 'short'),
+        'protected_to_private' => false,
+    ))
+    ->setRiskyAllowed(true)
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->in(__DIR__.'/src')
+    )
+;

--- a/bin/csfix.sh
+++ b/bin/csfix.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+MASTER_MERGE_BASE=($(git merge-base origin/master HEAD))
+COMMIT_RANGE="$MASTER_MERGE_BASE..HEAD"
+IFS=$'\n'; COMMIT_SCA_FILES=($(git diff --name-only --diff-filter=ACMRTUXB "${COMMIT_RANGE}")); unset IFS
+./vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --using-cache=no --path-mode=intersection "${COMMIT_SCA_FILES[@]}"

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "symfony/dependency-injection": "2.8 - 3.3",
     "symfony/framework-bundle": "~2.8",
     "symfony/property-access": "2.8 - 3.3",
-    "symfony/security-core": "2.8 - 3.3"
+    "symfony/security-core": "2.8 - 3.3",
+    "twig/extensions": "^1.5"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.7",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     "symfony/security-core": "2.8 - 3.3"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.7"
+    "phpunit/phpunit": "^5.7",
+    "friendsofphp/php-cs-fixer": "^2.7"
   },
   "minimum-stability": "stable",
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -13,17 +13,19 @@
     }
   ],
   "require": {
-    "php": "~5.4 || ^7.0",
+    "php": "~5.6 || ^7.0",
     "alom/graphviz": "~1.0",
-    "doctrine/orm": "~2.1",
     "doctrine/doctrine-bundle": "~1.4",
-    "symfony/framework-bundle": "~2.7|~3.0|~4.0",
+    "doctrine/orm": "~2.1",
+    "ocramius/proxy-manager": "~1.0",
     "symfony/console": "~2.7|~3.0|~4.0",
     "symfony/dependency-injection": "~2.7|~3.0|~4.0",
-    "ocramius/proxy-manager": "~1.0"
+    "symfony/framework-bundle": "~2.7|~3.0|~4.0",
+    "symfony/property-access": "~2.8",
+    "symfony/security-core": "~2.8"
   },
   "require-dev": {
-    "phpunit/phpunit": "^6.1"
+    "phpunit/phpunit": "^5.7"
   },
   "minimum-stability": "dev",
   "autoload": {
@@ -34,5 +36,8 @@
   },
   "scripts": {
     "test": "phpunit"
+  },
+  "config": {
+    "sort-packages": true
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,17 +17,17 @@
     "alom/graphviz": "~1.0",
     "doctrine/doctrine-bundle": "~1.4",
     "doctrine/orm": "~2.1",
-    "ocramius/proxy-manager": "~1.0",
-    "symfony/console": "~2.7|~3.0|~4.0",
-    "symfony/dependency-injection": "~2.7|~3.0|~4.0",
-    "symfony/framework-bundle": "~2.7|~3.0|~4.0",
-    "symfony/property-access": "~2.8",
-    "symfony/security-core": "~2.8"
+    "ocramius/proxy-manager": "~1.0 || ~2.0",
+    "symfony/console": "2.8 - 3.3",
+    "symfony/dependency-injection": "2.8 - 3.3",
+    "symfony/framework-bundle": "~2.8",
+    "symfony/property-access": "2.8 - 3.3",
+    "symfony/security-core": "2.8 - 3.3"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.7"
   },
-  "minimum-stability": "dev",
+  "minimum-stability": "stable",
   "autoload": {
     "psr-4": {
       "StateMachine\\": "src/StateMachine",

--- a/src/StateMachine/Tests/EventsTest.php
+++ b/src/StateMachine/Tests/EventsTest.php
@@ -2,13 +2,14 @@
 
 namespace StateMachine\Tests;
 
+use StateMachine\Exception\StateMachineException;
 use StateMachine\Tests\Fixtures\StateMachineFixtures;
 
 class EventsTest extends \PHPUnit_Framework_TestCase
 {
     public function testTriggersUndefinedEvent()
     {
-        $this->setExpectedException('StateMachine\Exception\StateMachineException');
+        $this->expectException(StateMachineException::class);
         $stateMachine = StateMachineFixtures::getOrderStateMachine();
         $stateMachine->boot();
 

--- a/src/StateMachine/Tests/HistoryTest.php
+++ b/src/StateMachine/Tests/HistoryTest.php
@@ -4,6 +4,7 @@ namespace StateMachine\Tests;
 
 use StateMachine\Event\PreTransitionEvent;
 use StateMachine\Event\TransitionEvent;
+use StateMachine\Exception\StateMachineException;
 use StateMachine\State\StateInterface;
 use StateMachine\StateMachine\StateMachine;
 use StateMachine\Tests\Fixtures\StateMachineFixtures;
@@ -57,7 +58,7 @@ class HistoryTest extends \PHPUnit_Framework_TestCase
 
     public function testHistoryWithTwoMovesWithFirstFailed()
     {
-        $this->setExpectedException('StateMachine\Exception\StateMachineException');
+        $this->expectException(StateMachineException::class);
         $stateMachine = StateMachineFixtures::getOrderStateMachine();
         $stateMachine->addGuard(
             function (TransitionEvent $transitionEvent) {

--- a/src/StateMachine/Tests/PersistentManagerTest.php
+++ b/src/StateMachine/Tests/PersistentManagerTest.php
@@ -2,7 +2,9 @@
 
 namespace StateMachine\Tests;
 
+use Doctrine\Common\Persistence\ObjectManager;
 use StateMachine\StateMachine\PersistentManager;
+use StateMachine\StateMachine\StatefulInterface;
 
 class PersistentManagerTest extends \PHPUnit_Framework_TestCase
 {
@@ -22,9 +24,10 @@ class PersistentManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testPreTransitionWithoutORM()
     {
-        $objectManagerMock = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectManager')
+        $objectManagerMock = $this->getMockBuilder(ObjectManager::class)
             ->disableOriginalConstructor()
-            ->getMock();
+            ->setMethods(['beginTransaction'])
+            ->getMockForAbstractClass();
 
         $objectManagerMock->expects($this->never())
             ->method('beginTransaction');
@@ -36,9 +39,10 @@ class PersistentManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testFailTransitionWithoutORM()
     {
-        $objectManagerMock = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectManager')
+        $objectManagerMock = $this->getMockBuilder(ObjectManager::class)
             ->disableOriginalConstructor()
-            ->getMock();
+            ->setMethods(['rollBack'])
+            ->getMockForAbstractClass();
 
         $objectManagerMock->expects($this->never())
             ->method('rollBack');
@@ -111,14 +115,10 @@ class PersistentManagerTest extends \PHPUnit_Framework_TestCase
         $stateMachineMock = $this->getMockBuilder('StateMachine\StateMachine\StateMachineInterface')
             ->disableOriginalConstructor()->getMock();
 
-        $statefulMock = $this->getMock(
-            'StateMachine\StateMachine\StatefulInterface',
-            [
-                'getStateMachine',
-                'setStateMachine',
-                'getId',
-            ]
-        );
+        $statefulMock = $this->getMockBuilder(StatefulInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getStateMachine', 'setStateMachine', 'getId'])
+            ->getMock();
 
         $statefulMock->expects($this->any())
             ->method('getStateMachine')

--- a/src/StateMachine/Tests/PersistentManagerTest.php
+++ b/src/StateMachine/Tests/PersistentManagerTest.php
@@ -106,7 +106,7 @@ class PersistentManagerTest extends \PHPUnit_Framework_TestCase
 
     private function getTransitionEventMock($options, $transitionMock = null)
     {
-        if ($transitionMock == null) {
+        if (null == $transitionMock) {
             $transitionMock = $this->getMockBuilder('StateMachine\Transition\TransitionInterface')
                 ->disableOriginalConstructor()
                 ->getMock();

--- a/src/StateMachine/Tests/StateMachineTest.php
+++ b/src/StateMachine/Tests/StateMachineTest.php
@@ -5,6 +5,7 @@ namespace StateMachine\Tests;
 use StateMachine\Accessor\StateAccessor;
 use StateMachine\Event\PreTransitionEvent;
 use StateMachine\Event\TransitionEvent;
+use StateMachine\Exception\StateMachineException;
 use StateMachine\History\History;
 use StateMachine\State\StateInterface;
 use StateMachine\StateMachine\StateMachine;
@@ -21,10 +22,8 @@ class StateMachineTest extends \PHPUnit_Framework_TestCase
 
     public function testWithNoInitialState()
     {
-        $this->setExpectedException(
-            'StateMachine\Exception\StateMachineException',
-            'No initial state is found'
-        );
+        $this->expectException(StateMachineException::class);
+        $this->expectExceptionMessage('No initial state is found');
 
         $stateMachine = new StateMachine(new Order(1));
         $stateMachine->addState('pending');
@@ -41,9 +40,7 @@ class StateMachineTest extends \PHPUnit_Framework_TestCase
 
     public function testWithHistoryStateConflict()
     {
-        $this->setExpectedException(
-            'StateMachine\Exception\StateMachineException'
-        );
+        $this->expectException(StateMachineException::class);
         $object = new Order(2);
         $object->setState('new');
         $stateMachine = new StateMachine($object);
@@ -98,8 +95,8 @@ class StateMachineTest extends \PHPUnit_Framework_TestCase
 
     public function testTwoInitialStates()
     {
-        $this->setExpectedException(
-            'StateMachine\Exception\StateMachineException',
+        $this->expectException(StateMachineException::class);
+        $this->expectExceptionMessage(
             'Statemachine cannot have more than one initial state, current initial state is (pending)'
         );
 
@@ -221,8 +218,8 @@ class StateMachineTest extends \PHPUnit_Framework_TestCase
 
     public function testNotAllowedTransition()
     {
-        $this->setExpectedException(
-            'StateMachine\Exception\StateMachineException',
+        $this->expectException(StateMachineException::class);
+        $this->expectExceptionMessage(
             "There's no transition defined from (pending) to (shipped), allowed transitions to : [ checking_out,cancelled ]"
         );
 
@@ -241,7 +238,7 @@ class StateMachineTest extends \PHPUnit_Framework_TestCase
 
     public function testWithWrongProperty()
     {
-        $this->setExpectedException('StateMachine\Exception\StateMachineException');
+        $this->expectException(StateMachineException::class);
         $stateMachine = new StateMachine(new Order(1), null, null, new StateAccessor('wrong_state'));
 
         $stateMachine->addState('pending', StateInterface::TYPE_INITIAL);
@@ -270,7 +267,7 @@ class StateMachineTest extends \PHPUnit_Framework_TestCase
 
     public function testAddTransitionToBootedMachine()
     {
-        $this->setExpectedException('StateMachine\Exception\StateMachineException');
+        $this->expectException(StateMachineException::class);
         $stateMachine = StateMachineFixtures::getOrderStateMachine();
         $stateMachine->addTransition('new', 'cancelled');
         $stateMachine->boot();
@@ -278,7 +275,7 @@ class StateMachineTest extends \PHPUnit_Framework_TestCase
 
     public function testPreTransitionToBootedMachine()
     {
-        $this->setExpectedException('StateMachine\Exception\StateMachineException');
+        $this->expectException(StateMachineException::class);
         $stateMachine = StateMachineFixtures::getOrderStateMachine();
         $stateMachine->boot();
         $stateMachine->addPostTransition(
@@ -290,7 +287,7 @@ class StateMachineTest extends \PHPUnit_Framework_TestCase
 
     public function testPostTransitionToBootedMachine()
     {
-        $this->setExpectedException('StateMachine\Exception\StateMachineException');
+        $this->expectException(StateMachineException::class);
         $stateMachine = StateMachineFixtures::getOrderStateMachine();
         $stateMachine->boot();
         $stateMachine->addPreTransition(
@@ -302,7 +299,7 @@ class StateMachineTest extends \PHPUnit_Framework_TestCase
 
     public function testGuardToBootedMachine()
     {
-        $this->setExpectedException('StateMachine\Exception\StateMachineException');
+        $this->expectException(StateMachineException::class);
         $stateMachine = StateMachineFixtures::getOrderStateMachine();
         $stateMachine->boot();
         $stateMachine->addGuard(
@@ -314,10 +311,8 @@ class StateMachineTest extends \PHPUnit_Framework_TestCase
 
     public function testAddTransitionWithBootedMachine()
     {
-        $this->setExpectedException(
-            'StateMachine\Exception\StateMachineException',
-            'Cannot add more transitions to booted StateMachine'
-        );
+        $this->expectException(StateMachineException::class);
+        $this->expectExceptionMessage('Cannot add more transitions to booted StateMachine');
         $stateMachine = StateMachineFixtures::getOrderStateMachine();
         $stateMachine->boot();
         $stateMachine->addTransition('new->committed');
@@ -325,28 +320,29 @@ class StateMachineTest extends \PHPUnit_Framework_TestCase
 
     public function testGetAllowedTransitionsForNonBootedMachine()
     {
-        $this->setExpectedException('StateMachine\Exception\StateMachineException');
+        $this->expectException(StateMachineException::class);
         $stateMachine = StateMachineFixtures::getOrderStateMachine();
         $stateMachine->getAllowedTransitions();
     }
 
     public function testCanTransitToForNonBootedMachine()
     {
-        $this->setExpectedException('StateMachine\Exception\StateMachineException');
+        $this->expectException(StateMachineException::class);
         $stateMachine = StateMachineFixtures::getOrderStateMachine();
         $stateMachine->canTransitionTo('paid');
     }
 
     public function testTransitToForNonBootedMachine()
     {
-        $this->setExpectedException('StateMachine\Exception\StateMachineException');
+        $this->expectException(StateMachineException::class);
         $stateMachine = StateMachineFixtures::getOrderStateMachine();
         $stateMachine->transitionTo('paid');
     }
 
     public function testBootTwice()
     {
-        $this->setExpectedException('StateMachine\Exception\StateMachineException', 'Statemachine is already booted');
+        $this->expectException(StateMachineException::class);
+        $this->expectExceptionMessage('Statemachine is already booted');
         $stateMachine = StateMachineFixtures::getOrderStateMachine();
         $stateMachine->boot();
         $stateMachine->boot();
@@ -475,10 +471,8 @@ class StateMachineTest extends \PHPUnit_Framework_TestCase
 
     public function testNewObjectWithStateValueSetToNormal()
     {
-        $this->setExpectedException(
-            'StateMachine\Exception\StateMachineException',
-            'Object has state: B, which is not final or initial'
-        );
+        $this->expectException(StateMachineException::class);
+        $this->expectExceptionMessage('Object has state: B, which is not final or initial');
         //new object
         $object = new Order(null);
         $object->setState('B');
@@ -528,10 +522,8 @@ class StateMachineTest extends \PHPUnit_Framework_TestCase
 
     public function testNotAllowedEvent()
     {
-        $this->setExpectedException(
-            'StateMachine\Exception\StateMachineException',
-            'Event A_D didn\'t match any transition, allowed events for state A are [A_B,A_C]'
-        );
+        $this->expectException(StateMachineException::class);
+        $this->expectExceptionMessage('Event A_D didn\'t match any transition, allowed events for state A are [A_B,A_C]');
         //new object
         $object = new Order(1);
         $object->setState('A');

--- a/src/StateMachine/Tests/TransitionsTest.php
+++ b/src/StateMachine/Tests/TransitionsTest.php
@@ -14,7 +14,6 @@ class TransitionsTest extends \PHPUnit_Framework_TestCase
         $stateMachine = StateMachineFixtures::getBidStateMachine();
         $stateMachine->addPreTransition(
             function () {
-
             },
             'non_existing',
             'non_existing'
@@ -44,7 +43,6 @@ class TransitionsTest extends \PHPUnit_Framework_TestCase
         $stateMachine = StateMachineFixtures::getBidStateMachine();
         $stateMachine->addPostTransition(
             function () {
-
             },
             'non_existing',
             'non_existing'

--- a/src/StateMachine/Tests/TransitionsTest.php
+++ b/src/StateMachine/Tests/TransitionsTest.php
@@ -3,13 +3,14 @@
 namespace StateMachine\Tests;
 
 use StateMachine\Event\TransitionEvent;
+use StateMachine\Exception\StateMachineException;
 use StateMachine\Tests\Fixtures\StateMachineFixtures;
 
 class TransitionsTest extends \PHPUnit_Framework_TestCase
 {
     public function testPreTransitionOnNonExistingTransition()
     {
-        $this->setExpectedException('StateMachine\Exception\StateMachineException');
+        $this->expectException(StateMachineException::class);
         $stateMachine = StateMachineFixtures::getBidStateMachine();
         $stateMachine->addPreTransition(
             function () {
@@ -39,7 +40,7 @@ class TransitionsTest extends \PHPUnit_Framework_TestCase
 
     public function testPostTransitionOnNonExistingTransition()
     {
-        $this->setExpectedException('StateMachine\Exception\StateMachineException');
+        $this->expectException(StateMachineException::class);
         $stateMachine = StateMachineFixtures::getBidStateMachine();
         $stateMachine->addPostTransition(
             function () {

--- a/src/StateMachineBundle/Resources/config/services.yml
+++ b/src/StateMachineBundle/Resources/config/services.yml
@@ -2,26 +2,26 @@ services:
     statemachine.manager:
         class: StateMachineBundle\StateMachine\StateMachineManager
         arguments:
-            - @statemachine.history_manager
-            - @doctrine
-            - @statemachine.proxy_factory
-            - @statemachine.logger
+            - '@statemachine.history_manager'
+            - '@doctrine'
+            - '@statemachine.proxy_factory'
+            - '@statemachine.logger'
         calls:
-            - [setContainer,[@service_container]]
+            - [setContainer,['@service_container']]
 
     statemachine.subscriber.doctrine_loader:
         class: StateMachineBundle\Subscriber\LifeCycleEventsSubscriber
         arguments:
-            - @statemachine.manager
-            - @security.token_storage
+            - '@statemachine.manager'
+            - '@security.token_storage'
         tags:
             - { name: doctrine.event_subscriber }
 
     statemachine.history_manager:
         class: StateMachineBundle\History\PersistentHistoryManager
         arguments:
-            - @doctrine
-            - @security.token_storage
+            - '@doctrine'
+            - '@security.token_storage'
 
     statemachine.twig.state_machine:
         class: StateMachineBundle\Twig\StateMachineExtension
@@ -31,21 +31,21 @@ services:
     statemachine.logger:
         class: StateMachine\Logger\Logger
         arguments:
-            - @logger
+            - '@logger'
         tags:
             - { name: monolog.logger, channel: state_machine }
 
     statemachine.data_collector:
         class: StateMachineBundle\DataCollector\StateMachineDataCollector
         arguments:
-            - @statemachine.logger
+            - '@statemachine.logger'
         tags:
             - { name: data_collector, id: state_machine, template: 'StateMachineBundle:Collector:state_machine' }
 
     statemachine.proxy_factory:
         class: ProxyManager\Factory\LazyLoadingValueHolderFactory
         arguments:
-            - @statemachine.proxy_configuration
+            - '@statemachine.proxy_configuration'
 
     statemachine.proxy_configuration:
         class: ProxyManager\Configuration
@@ -58,7 +58,7 @@ services:
     statemachine.commands.trigger:
         class: StateMachineBundle\Command\StateMachineCommand
         arguments:
-            - @statemachine.manager
-            - @doctrine
+            - '@statemachine.manager'
+            - '@doctrine'
         tags:
             - { name: console.command }

--- a/src/StateMachineBundle/Tests/History/PersistentHistoryManagerTest.php
+++ b/src/StateMachineBundle/Tests/History/PersistentHistoryManagerTest.php
@@ -4,9 +4,12 @@ namespace StateMachineBundle\Tests\History;
 
 use StateMachine\History\History;
 use StateMachine\History\HistoryCollection;
+use StateMachine\StateMachine\StatefulInterface;
 use StateMachine\Tests\Entity\Order;
 use StateMachineBundle\History\PersistentHistoryManager;
 use StateMachineBundle\Tests\Entity\BlameableHistory;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class PersistentHistoryManagerTest extends \PHPUnit_Framework_TestCase
 {
@@ -96,7 +99,7 @@ class PersistentHistoryManagerTest extends \PHPUnit_Framework_TestCase
         $blameableStateChange = new BlameableHistory();
         $blameableStateChange->setOptions(['transaction' => true]);
 
-        $userMock = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
+        $userMock = $this->createMock('Symfony\Component\Security\Core\User\UserInterface');
         $tokenStorageMock = $this->getTokenStorageMock($userMock);
 
         $historyManager = $this->getHistoryManager(
@@ -259,14 +262,9 @@ class PersistentHistoryManagerTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $statefulMock = $this->getMock(
-            'StateMachine\StateMachine\StatefulInterface',
-            [
-                'getStateMachine',
-                'setStateMachine',
-                'getId',
-            ]
-        );
+        $statefulMock = $this->getMockBuilder(StatefulInterface::class)
+            ->setMethods(['getStateMachine', 'setStateMachine', 'getId'])
+            ->getMock();
 
         $statefulMock->expects($this->any())
             ->method('getStateMachine')
@@ -286,13 +284,14 @@ class PersistentHistoryManagerTest extends \PHPUnit_Framework_TestCase
 
     private function getTokenStorageMock($user = null)
     {
-        $tokenStoragetMock = $this->getMockBuilder(
-            'Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface'
-        )->getMock();
+        $tokenStoragetMock = $this->getMockBuilder(TokenStorageInterface::class)
+            ->setMethods(['getToken'])
+            ->getMockForAbstractClass();
 
-        $tokenMock = $this->getMockBuilder(
-            'Symfony\Component\Security\Core\Authentication\Token\TokenInterface'
-        )->getMock();
+        $tokenMock = $this->getMockBuilder(TokenInterface::class)
+            ->setMethods(['getUser'])
+            ->getMockForAbstractClass();
+
         $tokenMock->expects($this->any())
             ->method('getUser')
             ->willReturn($user);

--- a/src/StateMachineBundle/Tests/StateMachineManagerTest.php
+++ b/src/StateMachineBundle/Tests/StateMachineManagerTest.php
@@ -3,17 +3,19 @@
 namespace StateMachineBundle\Tests;
 
 use ProxyManager\Factory\LazyLoadingValueHolderFactory;
+use StateMachine\Exception\StateMachineException;
 use StateMachine\History\HistoryCollection;
 use StateMachineBundle\StateMachine\StateMachineManager;
 use StateMachineBundle\Tests\Entity\ChildOrder;
 use StateMachineBundle\Tests\Entity\Order;
 use StateMachineBundle\Tests\Listeners\MockListener;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class StateMachineManagerTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetUndefinedStateMachine()
     {
-        $this->setExpectedException("StateMachine\Exception\StateMachineException");
+        $this->expectException(StateMachineException::class);
         $factory = $this->getFactory();
         $factory->get(new Order(1));
     }
@@ -91,9 +93,9 @@ class StateMachineManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testRegisterDefinitionTwice()
     {
-        $this->setExpectedException(
-            "StateMachine\Exception\StateMachineException",
-            "Cannot register statemachine's same class, with same version for more than one time, class: StateMachineBundle\Tests\Entity\Order"
+        $this->expectException(StateMachineException::class);
+        $this->expectExceptionMessage(
+            'Cannot register statemachine\'s same class, with same version for more than one time, class: StateMachineBundle\Tests\Entity\Order'
         );
         $definition = $this->getDefinition();
         $factory = $this->getFactory();
@@ -113,7 +115,7 @@ class StateMachineManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetOneNotFoundDefinition()
     {
-        $this->setExpectedException("StateMachine\Exception\StateMachineException");
+        $this->expectException(StateMachineException::class);
         $definition = $this->getDefinition();
         $factory = $this->getFactory();
         $factory->register($definition);
@@ -135,7 +137,7 @@ class StateMachineManagerTest extends \PHPUnit_Framework_TestCase
         $entityManagerMock = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->getMock();
-        $containerMock = $this->getMock('\Symfony\Component\DependencyInjection\ContainerInterface');
+        $containerMock = $this->createMock(ContainerInterface::class);
         $containerMock->method('get')
             ->willReturn(new MockListener());
 
@@ -176,7 +178,7 @@ class StateMachineManagerTest extends \PHPUnit_Framework_TestCase
         $entityManagerMock = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->getMock();
-        $containerMock = $this->getMock('\Symfony\Component\DependencyInjection\ContainerInterface');
+        $containerMock = $this->createMock(ContainerInterface::class);
         $containerMock->method('get')
             ->willReturn(new MockListener());
 
@@ -215,7 +217,7 @@ class StateMachineManagerTest extends \PHPUnit_Framework_TestCase
         $entityManagerMock = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->getMock();
-        $containerMock = $this->getMock('\Symfony\Component\DependencyInjection\ContainerInterface');
+        $containerMock = $this->createMock(ContainerInterface::class);
         $containerMock->method('get')
             ->willReturn(new MockListener());
 

--- a/src/StateMachineBundle/Tests/Subscriber/LifeCycleEventsSubscriberTest.php
+++ b/src/StateMachineBundle/Tests/Subscriber/LifeCycleEventsSubscriberTest.php
@@ -135,7 +135,6 @@ class LifeCycleEventsSubscriberTest extends \PHPUnit_Framework_TestCase
         $smManagerMock->expects($this->once())
             ->method('clear');
 
-
         $subscriber = new LifeCycleEventsSubscriber($smManagerMock, $this->getTokenStorage());
         $subscriber->onClear();
     }

--- a/src/StateMachineBundle/Tests/Subscriber/LifeCycleEventsSubscriberTest.php
+++ b/src/StateMachineBundle/Tests/Subscriber/LifeCycleEventsSubscriberTest.php
@@ -2,9 +2,13 @@
 
 namespace StateMachineBundle\Tests\Subscriber;
 
+use Doctrine\Common\Persistence\ObjectManager;
+use StateMachine\EventDispatcher\EventDispatcher;
+use StateMachine\StateMachine\StateMachineInterface;
 use StateMachineBundle\Subscriber\LifeCycleEventsSubscriber;
 use StateMachineBundle\Tests\Entity\NonStatefulOrder;
 use StateMachineBundle\Tests\Entity\Order;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class LifeCycleEventsSubscriberTest extends \PHPUnit_Framework_TestCase
 {
@@ -25,12 +29,15 @@ class LifeCycleEventsSubscriberTest extends \PHPUnit_Framework_TestCase
         $subscriber->postLoad($eventArgsMock);
     }
 
-    public function testPostLoadWithStateFulEntity()
+    public function testPostLoadWithStatefulEntity()
     {
-        $stateMachineMock = $this->getMock('StateMachine\StateMachine\StateMachineInterface');
+        $stateMachineMock = $this->getMockBuilder(StateMachineInterface::class)
+            ->setMethods(['getEventDispatcher'])
+            ->getMockForAbstractClass();
+
         $stateMachineMock->expects($this->any())
             ->method('getEventDispatcher')
-            ->willReturn($this->getMock("StateMachine\EventDispatcher\EventDispatcher"));
+            ->willReturn($this->createMock(EventDispatcher::class));
 
         $smManagerMock = $this->getMockBuilder('\StateMachineBundle\StateMachine\StateMachineManager')
             ->disableOriginalConstructor()->getMock();
@@ -49,7 +56,7 @@ class LifeCycleEventsSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $eventArgsMock->expects($this->any())
             ->method('getEntityManager')
-            ->willReturn($this->getMock('Doctrine\Common\Persistence\ObjectManager'));
+            ->willReturn($this->createMock(ObjectManager::class));
 
         $subscriber = new LifeCycleEventsSubscriber($smManagerMock, $this->getTokenStorage());
 
@@ -57,7 +64,7 @@ class LifeCycleEventsSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('StateMachine\StateMachine\StateMachineInterface', $stateFulObject->getStateMachine());
     }
 
-    public function testPrePersistWithNonStateFulEntity()
+    public function testPrePersistWithNonStatefulEntity()
     {
         $smManagerMock = $this->getMockBuilder('\StateMachineBundle\StateMachine\StateMachineManager')
             ->disableOriginalConstructor()->getMock();
@@ -71,19 +78,22 @@ class LifeCycleEventsSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $eventArgsMock->expects($this->any())
             ->method('getEntityManager')
-            ->willReturn($this->getMock('Doctrine\Common\Persistence\ObjectManager'));
+            ->willReturn($this->createMock(ObjectManager::class));
 
         $subscriber = new LifeCycleEventsSubscriber($smManagerMock, $this->getTokenStorage());
 
         $subscriber->prePersist($eventArgsMock);
     }
 
-    public function testPrePersistWithStateFulEntity()
+    public function testPrePersistWithStatefulEntity()
     {
-        $stateMachineMock = $this->getMock('StateMachine\StateMachine\StateMachineInterface');
+        $stateMachineMock = $this->getMockBuilder(StateMachineInterface::class)
+            ->setMethods(['getEventDispatcher'])
+            ->getMockForAbstractClass();
+
         $stateMachineMock->expects($this->any())
             ->method('getEventDispatcher')
-            ->willReturn($this->getMock("StateMachine\EventDispatcher\EventDispatcher"));
+            ->willReturn($this->createMock(EventDispatcher::class));
 
         $smManagerMock = $this->getMockBuilder('\StateMachineBundle\StateMachine\StateMachineManager')
             ->disableOriginalConstructor()->getMock();
@@ -102,7 +112,7 @@ class LifeCycleEventsSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $eventArgsMock->expects($this->any())
             ->method('getEntityManager')
-            ->willReturn($this->getMock('Doctrine\Common\Persistence\ObjectManager'));
+            ->willReturn($this->createMock(ObjectManager::class));
 
         $subscriber = new LifeCycleEventsSubscriber($smManagerMock, $this->getTokenStorage());
 
@@ -132,10 +142,6 @@ class LifeCycleEventsSubscriberTest extends \PHPUnit_Framework_TestCase
 
     private function getTokenStorage()
     {
-        $tokenStorageMock = $this->getMock(
-            'Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface'
-        );
-
-        return $tokenStorageMock;
+        return $this->createMock(TokenStorageInterface::class);
     }
 }

--- a/src/test_bootstrap.php
+++ b/src/test_bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 
-if (!($loader = include __DIR__.'/../../../../vendor/autoload.php')) {
+if (!($loader = include __DIR__.'/../vendor/autoload.php')) {
     die(<<<EOT
 You need to install the project dependencies using Composer:
 $ wget http://getcomposer.org/composer.phar


### PR DESCRIPTION
- checking PHP7 compatibility
- ~checking Symfony 3.3 compatibility~ requires changing of routing.yml which is BC break. Need to be discused
- adding circleci php 7.1 build
- adding code style checker
- fixing composer dependencies


it is a parent of https://github.com/zencap/state-machine/pull/29